### PR TITLE
use rmarkdown to build vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     testthat
 License: GPL v.2
 Suggests:
-    knitr
-VignetteBuilder: knitr
+    knitr,
+    rmarkdown
+VignetteBuilder: rmarkdown
 RoxygenNote: 5.0.1


### PR DESCRIPTION
The package can be built again and installed for new version of R with this change. 
